### PR TITLE
big fix: last prompt is duplicated in jsonMap['messages'] in file groq_chat.dart

### DIFF
--- a/lib/models/groq_api.dart
+++ b/lib/models/groq_api.dart
@@ -2,13 +2,12 @@ import 'dart:convert';
 
 import 'package:groq_sdk/extensions/groq_json_extensions.dart';
 import 'package:groq_sdk/models/chat_event.dart';
+import 'package:groq_sdk/models/groq_audio_response.dart';
 import 'package:groq_sdk/models/groq_chat.dart';
 import 'package:groq_sdk/models/groq_exceptions.dart';
 import 'package:groq_sdk/models/groq_llm_model.dart';
-import 'package:groq_sdk/models/groq_message.dart';
 import 'package:groq_sdk/models/groq_rate_limit_information.dart';
 import 'package:groq_sdk/models/groq_response.dart';
-import 'package:groq_sdk/models/groq_audio_response.dart';
 import 'package:groq_sdk/models/groq_usage.dart';
 import 'package:groq_sdk/utils/auth_http.dart';
 import 'package:groq_sdk/utils/groq_parser.dart';
@@ -53,7 +52,6 @@ class GroqApi {
   static Future<(GroqResponse, GroqUsage, GroqRateLimitInformation)>
       getNewChatCompletion({
     required String apiKey,
-    required GroqMessage prompt,
     required GroqChat chat,
     required bool expectJSON,
   }) async {
@@ -72,7 +70,6 @@ class GroqApi {
       // messages.add(message.request.toJson());
       // messages.add(message.response!.choices.first.messageData.toJson());
     }
-    messages.add(prompt.toJson());
     jsonMap['messages'] = messages;
     jsonMap['model'] = chat.model;
     if (chat.registeredTools.isNotEmpty) {

--- a/lib/models/groq_chat.dart
+++ b/lib/models/groq_chat.dart
@@ -420,7 +420,6 @@ class GroqChat {
     try {
       (response, usage, rateLimitInfo) = await GroqApi.getNewChatCompletion(
         apiKey: _apiKey,
-        prompt: request,
         chat: this,
         expectJSON: expectJSON,
       );


### PR DESCRIPTION
Logging ` jsonMap['messages']` after line 76 in `groq_api.dart`, we can see that the last prompt sent is repeated.  

This is because in line 75 ` messages.add(prompt.toJson());` we add the prompt to our of messages, but from line 415  ` _chatItems.add(RequestChatEvent(request));` in `groq_chat.dart` we already added the prompt to our list of chatItems.